### PR TITLE
Add web prototype for floorplan generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# AI Floorplan Assistant
+
+This project provides a simple web interface to upload a plot layout (image, PDF, or IFC). The app interacts with the user to collect design requirements and generates basic floor plan options.
+
+## Features
+
+- Upload plot files in image (`.png`, `.jpg`), PDF, or IFC format.
+- Choose building type: villa, hotel, or office.
+- Interactive questions adjust based on building type.
+- Display placeholder floor plan options.
+
+## Requirements
+
+- Python 3.10+
+- Install packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+Start the web application with:
+
+```bash
+streamlit run app.py
+```
+
+## Notes
+
+This is a minimal prototype inspired by Finch3D/TestFit. The floor plan generation uses simple geometric placeholders. Additional logic is needed for production use.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,66 @@
+import streamlit as st
+from PIL import Image
+from pdf2image import convert_from_path
+import ifcopenshell
+import io
+
+from floorplan_generator import generate_random_plan
+
+st.title("AI Floorplan Assistant")
+
+# File upload
+uploaded_file = st.file_uploader(
+    "Upload plot layout (image/PDF/IFC)",
+    type=["png", "jpg", "jpeg", "pdf", "ifc"],
+)
+
+plot_image = None
+if uploaded_file is not None:
+    file_bytes = uploaded_file.read()
+    suffix = uploaded_file.name.split(".")[-1].lower()
+    if suffix in {"png", "jpg", "jpeg"}:
+        plot_image = Image.open(io.BytesIO(file_bytes))
+    elif suffix == "pdf":
+        images = convert_from_path(uploaded_file)
+        if images:
+            plot_image = images[0]
+    elif suffix == "ifc":
+        try:
+            ifc = ifcopenshell.file.from_string(file_bytes.decode("utf-8"))
+            # Placeholder: create a blank image for display
+            plot_image = Image.new("RGB", (400, 400), color="white")
+        except Exception:
+            st.error("Failed to read IFC file")
+
+if plot_image is not None:
+    st.image(plot_image, caption="Plot layout", use_column_width=True)
+
+# Step 1: building type
+building_type = st.selectbox(
+    "What type of building?",
+    ["villa", "hotel", "office"],
+)
+
+# Additional questions
+questions = []
+if building_type == "villa":
+    bedrooms = st.number_input("Number of bedrooms", 1, 10, 3)
+    questions.append(("bedrooms", bedrooms))
+elif building_type == "hotel":
+    floors = st.number_input("Number of floors", 1, 20, 5)
+    rooms_per_floor = st.number_input("Rooms per floor", 5, 50, 20)
+    questions.extend([
+        ("floors", floors),
+        ("rooms_per_floor", rooms_per_floor),
+    ])
+else:  # office
+    floors = st.number_input("Number of floors", 1, 50, 10)
+    questions.append(("floors", floors))
+
+if st.button("Generate floor plan options"):
+    plans = [generate_random_plan() for _ in range(3)]
+    for idx, plan in enumerate(plans, 1):
+        st.subheader(f"Option {idx}")
+        # simple text representation
+        for room in plan.rooms:
+            st.write(f"Room at ({room.x},{room.y}) size {room.width}x{room.height}")

--- a/floorplan_generator.py
+++ b/floorplan_generator.py
@@ -1,0 +1,26 @@
+import random
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class Room:
+    x: int
+    y: int
+    width: int
+    height: int
+
+@dataclass
+class FloorPlan:
+    rooms: List[Room]
+
+
+def generate_random_plan(num_rooms: int = 4) -> FloorPlan:
+    """Generate a simple random floor plan."""
+    rooms = []
+    x_offset = 0
+    for _ in range(num_rooms):
+        width = random.randint(3, 8)
+        height = random.randint(3, 8)
+        rooms.append(Room(x=x_offset, y=0, width=width, height=height))
+        x_offset += width
+    return FloorPlan(rooms=rooms)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit>=1.25
+Pillow
+ifcopenshell
+pdf2image
+Shapely


### PR DESCRIPTION
## Summary
- add initial project README
- define placeholder floorplan generator
- create Streamlit web app to upload plot files and ask design questions
- specify Python dependencies

## Testing
- `python -m pip install -r requirements.txt` *(fails: could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684b0e004d9883339d48e2f2723f2972